### PR TITLE
fix: Update filenames and package.json type to allow commonjs resolution when bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
   "engines": {
     "node": ">=14.8"
   },
-  "type": "module",
+  "type": "commonjs",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "browser": "dist/index.umd.min.js",
   "types": "lib/index.d.ts",
   "exports": {
-    "require": "./dist/index.cjs",
+    "require": "./dist/index.js",
     "import": "./dist/index.mjs"
   },
   "bin": {
@@ -39,7 +39,8 @@
   },
   "files": [
     "bin",
-    "dist"
+    "dist",
+    "lib/index.d.ts"
   ],
   "scripts": {
     "prepare": "rollup -c",


### PR DESCRIPTION
Typescript compilation and module resolution failed attempting to use `build-number-generator` package with [Vite](https://vitejs.dev/) and Typescript.

PR adds missing `lib/index.d.ts` to `files` list in `package.json`.

After including a declaration file I received this error:
```
Error: Cannot find module '<project>/node_modules/build-number-generator/dist/index.cjs'
```
due to the incorrect filename under `exports.require` inside `package.json` - should be `index.js` according to rollup config.

And after that Vite failed attempting to require an ES module:
```
Error [ERR_REQUIRE_ESM]: require() of ES Module <project>/node_modules/build-number-generator/dist/index.js from <project>/vite.config.ts not supported.
index.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead rename index.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in <project>/node_modules/build-number-generator/package.json to treat all.js files as CommonJS (using .mjs for all ES modules instead).
```
I figured with the current setup that the `type` should be `commonjs` instead of renaming all `.js` files to `.cjs` and all `.mjs` files to `.js` and leaving `type:"module"`.

Including the types is safe as a patch IMO, but not sure about the `type:"commonjs"` change and if that would be a breaking change.
